### PR TITLE
Start embedding service faster by including installation step in build

### DIFF
--- a/clustering/Dockerfile
+++ b/clustering/Dockerfile
@@ -4,7 +4,7 @@ LABEL author="Jan Philip Bernius <janphilip.bernius@tum.de>"
 COPY ./clustering/requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -qr /tmp/requirements.txt
 # additional flag needed since hdbscan 0.8.29, see https://github.com/scikit-learn-contrib/hdbscan/issues/457
-RUN pip install --no-cache-dir hdbscan==0.8.31 --no-binary :all: --use-feature=no-binary-enable-wheel-cache
+RUN pip install --no-cache-dir hdbscan==0.8.32 --no-binary :all: --use-feature=no-binary-enable-wheel-cache
 
 WORKDIR /usr/src/app
 COPY ./clustering/src/ src/

--- a/clustering/Dockerfile
+++ b/clustering/Dockerfile
@@ -3,8 +3,8 @@ LABEL author="Jan Philip Bernius <janphilip.bernius@tum.de>"
 
 COPY ./clustering/requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -qr /tmp/requirements.txt
-# additional flag needed in hdbscan 0.8.29, see https://github.com/scikit-learn-contrib/hdbscan/issues/457
-RUN pip install --no-cache-dir hdbscan==0.8.29 --no-binary :all: --use-feature=no-binary-enable-wheel-cache
+# additional flag needed since hdbscan 0.8.29, see https://github.com/scikit-learn-contrib/hdbscan/issues/457
+RUN pip install --no-cache-dir hdbscan==0.8.31 --no-binary :all: --use-feature=no-binary-enable-wheel-cache
 
 WORKDIR /usr/src/app
 COPY ./clustering/src/ src/

--- a/clustering/Dockerfile
+++ b/clustering/Dockerfile
@@ -4,7 +4,7 @@ LABEL author="Jan Philip Bernius <janphilip.bernius@tum.de>"
 COPY ./clustering/requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -qr /tmp/requirements.txt
 # additional flag needed since hdbscan 0.8.29, see https://github.com/scikit-learn-contrib/hdbscan/issues/457
-RUN pip install --no-cache-dir hdbscan==0.8.32 --no-binary :all: --use-feature=no-binary-enable-wheel-cache
+RUN pip install --no-cache-dir hdbscan==0.8.33 --no-binary :all: --use-feature=no-binary-enable-wheel-cache
 
 WORKDIR /usr/src/app
 COPY ./clustering/src/ src/

--- a/clustering/src/TimerHandler.py
+++ b/clustering/src/TimerHandler.py
@@ -2,6 +2,7 @@ from logging import getLogger
 from src.ProcessingResource import ProcessingResource
 import os
 import threading
+import traceback
 
 process_lock = threading.Lock()     # Lock to prevent multiple calculations and restart during calculation
 # Interval to query task queue (in seconds)
@@ -47,6 +48,7 @@ class TimerThread(threading.Thread):
                     # Query task queue after timeout again
                     is_killed = self._kill.wait(self._interval)
             except Exception as e:
+                traceback.print_exc()
                 self.__logger.error("Exception while processing: {}".format(str(e)))
                 process_lock.release()
                 # Query task queue after timeout again

--- a/embedding/Dockerfile
+++ b/embedding/Dockerfile
@@ -21,6 +21,10 @@ RUN mkdir -p /usr/lib/nltk_data \
 # we need to upgrade numpy again for it to be detected by pytorch later
 RUN pip install --no-cache-dir numpy==1.24.1
 
+# install spacy dependencies
+COPY ./embedding/Makefile ./
+RUN make -C . spacy
+
 COPY ./embedding/src/ src/
 COPY ./text_preprocessing src/text_preprocessing
 

--- a/embedding/Makefile
+++ b/embedding/Makefile
@@ -1,6 +1,6 @@
 #!make
 
-all: .venv text_preprocessing ./.venv/nltk_data models
+all: .venv text_preprocessing ./.venv/nltk_data models spacy
 
 .venv: requirements.txt
 	python -m venv .venv
@@ -15,6 +15,9 @@ text_preprocessing: ../text_preprocessing
 
 models: ./src/resources/models/Makefile
 	@$(MAKE) -C ./src/resources/models
+
+spacy:
+	source .venv/bin/activate; python -m spacy download en_core_web_sm
 
 start:
 	source .venv/bin/activate; python start.py

--- a/embedding/src/TimerHandler.py
+++ b/embedding/src/TimerHandler.py
@@ -2,6 +2,7 @@ from logging import getLogger
 from src.ProcessingResource import ProcessingResource
 import os
 import threading
+import traceback
 
 process_lock = threading.Lock()     # Lock to prevent multiple calculations and restart during calculation
 # Interval to query task queue (in seconds)
@@ -47,6 +48,7 @@ class TimerThread(threading.Thread):
                     # Query task queue after timeout again
                     is_killed = self._kill.wait(self._interval)
             except Exception as e:
+                traceback.print_exc()
                 self.__logger.error("Exception while processing: {}".format(str(e)))
                 process_lock.release()
                 # Query task queue after timeout again

--- a/embedding/src/__init__.py
+++ b/embedding/src/__init__.py
@@ -1,7 +1,10 @@
 import spacy
-# Download the model so that importing it will work
-# see https://stackoverflow.com/a/47297686/4306257
-spacy.cli.download("en_core_web_sm")
+try:
+    from spacy.en import English
+except ImportError:
+    # Download the model so that importing it will work
+    # see https://stackoverflow.com/a/47297686/4306257
+    spacy.cli.download("en_core_web_sm")
 
 # Patch import
 from .patch.patch_spacy_tags import TAG_MAP

--- a/embedding/src/__init__.py
+++ b/embedding/src/__init__.py
@@ -1,9 +1,8 @@
 import spacy
-try:
-    from spacy.en import English
-except ImportError:
+if not spacy.util.is_package("en_core_web_sm"):
     # Download the model so that importing it will work
     # see https://stackoverflow.com/a/47297686/4306257
+    print("Downloading the spaCy English model (not installed yet)...")
     spacy.cli.download("en_core_web_sm")
 
 # Patch import

--- a/segmentation/src/TimerHandler.py
+++ b/segmentation/src/TimerHandler.py
@@ -2,6 +2,7 @@ from logging import getLogger
 from src.ProcessingResource import ProcessingResource
 import os
 import threading
+import traceback
 
 process_lock = threading.Lock()     # Lock to prevent multiple calculations and restart during calculation
 # Interval to query task queue (in seconds)
@@ -48,6 +49,7 @@ class TimerThread(threading.Thread):
                     # Query task queue after timeout again
                     is_killed = self._kill.wait(self._interval)
             except Exception as e:
+                traceback.print_exc()
                 self.__logger.error("Exception while processing: {}".format(str(e)))
                 process_lock.release()
                 # Query task queue after timeout again


### PR DESCRIPTION
This PR improves the startup speed of the Athena-CoFee embedding service. The current version is pretty slow on my machine because it always re-downloads spacy `en_core_web_sm` on start. This is now done in the build stage of the Docker container. This way, the embedding service can start faster and does not need a re-download each time it starts.

Also, the Docker build of the clustering service broke, which I also quickly fixed by updating the used version of `hdbscan`.